### PR TITLE
don't skip package_step, add --package option, group package-related options together

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1501,14 +1501,17 @@ class EasyBlock(object):
         packaging_tool = build_option('package_tool')
         opt_force = build_option('force')
 
-        if packaging_tool == "fpm":
+        if not build_option('package'):
+            _log.info("Skipping package step (not enabled)")
+
+        elif packaging_tool == "fpm":
             packaging_type = build_option('package_type') if build_option('package_type') else "rpm"
-             
+
             packagedir_src = package_fpm(self, path_to_module_file, package_type=packaging_type)
-   
+
             if not os.path.exists(packagedir_dest):
                 mkdir(packagedir_dest)
-        
+
             for src_file in glob.glob(os.path.join(packagedir_src, "*.%s" % packaging_type)):
                 src_filename = os.path.basename(src_file)
                 dest_file = os.path.join(packagedir_dest, src_filename)
@@ -1517,7 +1520,7 @@ class EasyBlock(object):
                 else:
                     shutil.copy(src_file, packagedir_dest)
         else:
-            _log.debug('Skipping package step')
+            raise EasyBuildError("Unknown packaging tool specified: %s", packaging_tool)
 
 
     def post_install_step(self):
@@ -1894,7 +1897,7 @@ class EasyBlock(object):
             (SANITYCHECK_STEP, 'sanity checking', [lambda x: x.sanity_check_step()], False),
             (CLEANUP_STEP, 'cleaning up', [lambda x: x.cleanup_step()], False),
             (MODULE_STEP, 'creating module', [lambda x: x.make_module_step()], False),
-            (PACKAGE_STEP, 'packaging', [lambda x: x.package_step()], True),
+            (PACKAGE_STEP, 'packaging', [lambda x: x.package_step()], False),
         ]
 
         # full list of steps, included iterated steps

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -96,6 +96,7 @@ BUILD_OPTIONS_CMDLINE = {
         'modules_footer',
         'only_blocks',
         'optarch',
+        'package_template',
         'package_tool',
         'package_type',
         'regtest_output_dir',
@@ -113,6 +114,7 @@ BUILD_OPTIONS_CMDLINE = {
         'force',
         'hidden',
         'module_only',
+        'package',
         'robot',
         'sequential',
         'set_gid_bit',
@@ -199,7 +201,6 @@ class ConfigurationVariables(FrozenDictKnownKeys):
         'module_syntax',
         'modules_tool',
         'packagepath',
-        'package_template',
         'prefix',
         'repository',
         'repositorypath',
@@ -372,12 +373,6 @@ def package_path():
     Return the path where built packages are copied to
     """
     return ConfigurationVariables()['packagepath']
-
-def package_template():
-    """
-    Returns the package template
-    """
-    return ConfigurationVariables()['package_template']
 
 def get_modules_tool():
     """

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -261,12 +261,6 @@ class EasyBuildOptions(GeneralOption):
                                None, 'store_or_None', None, {'metavar': "PATH"}),
             'modules-tool': ("Modules tool to use",
                              'choice', 'store', DEFAULT_MODULES_TOOL, sorted(avail_modules_tools().keys())),
-            'package-tool': ("Packaging tool to use",
-                             None, 'store_or_None', None),
-            'package-type': ("Packaging type to output to",
-                             None, 'store_or_None', None),
-            'package-template': ("A template string to name the package",
-                             None, 'store', DEFAULT_PACKAGE_TEMPLATE),
             'packagepath': ("The destination path for the packages built by package-tool",
                              None, 'store', mk_full_default_path('packagepath')),
             'prefix': (("Change prefix for buildpath, installpath, sourcepath and repositorypath "
@@ -353,6 +347,20 @@ class EasyBuildOptions(GeneralOption):
         })
 
         self.log.debug("regtest_options: descr %s opts %s" % (descr, opts))
+        self.add_group_parser(opts, descr)
+
+    def package_options(self):
+        # package-related options
+        descr = ("Package options", "Control packaging performed by EasyBuild.")
+
+        opts = OrderedDict({
+            'package': ("Enabling packaging", None, 'store_true', False),
+            'package-template': ("A template string to name the package", None, 'store', DEFAULT_PACKAGE_TEMPLATE),
+            'package-tool': ("Packaging tool to use", None, 'store_or_None', None),
+            'package-type': ("Packaging type to output to", None, 'store_or_None', None),
+        })
+
+        self.log.debug("package_options: descr %s opts %s" % (descr, opts))
         self.add_group_parser(opts, descr)
 
     def easyconfig_options(self):

--- a/easybuild/tools/packaging.py
+++ b/easybuild/tools/packaging.py
@@ -40,7 +40,7 @@ import pprint
 from vsc.utils import fancylogger
 
 from easybuild.tools.run import run_cmd
-from easybuild.tools.config import install_path, package_template
+from easybuild.tools.config import build_option
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 from easybuild.tools.build_log import EasyBuildError
@@ -60,10 +60,10 @@ def package_fpm(easyblock, modfile_path, package_type="rpm" ):
     try:
         os.chdir(workdir)
     except OSError, err:
-        raise EasybBuildError("Failed to chdir into workdir: %s : %s", workdir, err)
+        raise EasyBuildError("Failed to chdir into workdir: %s : %s", workdir, err)
 
     # default package_template is "eb-%(toolchain)s-%(name)s"
-    pkgtemplate = package_template()
+    pkgtemplate = build_option('package_template')
     full_ec_version = det_full_ec_version(easyblock.cfg)
     _log.debug("I got a package template that looks like: %s " % pkgtemplate )
 


### PR DESCRIPTION
`--skip` now works to package an existing installation, but i) regenerates the module file in the process, ii) requires use of `--force`.

We can probably do a better job, but I'd keep that for a follow-up PR.

Note that `--package` is now required to actually trigger the packaging. `--package-tool` is just a setting now, no action implied.

```
$ ls /wrk/hoste/EasyBuild/packages

$ eb --experimental --package-tool=fpm bzip2-1.0.6.eb -d --skip --package --force
== temporary log file in case of crash /tmp/hoste/eb-yuq3Ay/easybuild-K7TWr6.log
== processing EasyBuild easyconfig /homeappl/home/hoste/EasyBuild/easybuild-easyconfigs/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb
== building and installing bzip2/1.0.6...
== fetching files...
== creating build dir, resetting environment...
== unpacking [skipped]
== patching [skipped]
== preparing...
== configuring [skipped]
== building [skipped]
== testing [skipped]
== installing [skipped]
== taking care of extensions...
== postprocessing [skipped]
== sanity checking...
== cleaning up...
== creating module...
== packaging...
== COMPLETED: Installation ended successfully
== Results of the build can be found in the log file /homeappl/home/hoste/appl_taito/software/bzip2/1.0.6/easybuild/easybuild-bzip2-1.0.6-20150617.222109.log
== Build succeeded for 1 out of 1
== temporary log file(s) /tmp/hoste/eb-yuq3Ay/easybuild-K7TWr6.log* have been removed.
== temporary directory /tmp/hoste/eb-yuq3Ay has been removed.

$ ls /wrk/hoste/EasyBuild/packages
eb-bzip2-1.0.6-dummy-dummy-eb-1.x86_64.rpm
```
